### PR TITLE
Fixed Apple Touch Icon metadata

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,15 +7,15 @@
   <meta name="description" content="Wavemaker Novel Planning and Writing Software. " />
   <meta name="author" content="" />
   <link rel="shortcut icon" type="image/png" href="icons/favicon.ico" />
-  <link rel="/apple-touch-icon" sizes="57x57" href="icons/apple-icon-57x57.png">
-  <link rel="/apple-touch-icon" sizes="60x60" href="icons/apple-icon-60x60.png">
-  <link rel="/apple-touch-icon" sizes="72x72" href="icons/apple-icon-72x72.png">
-  <link rel="/apple-touch-icon" sizes="76x76" href="icons/apple-icon-76x76.png">
-  <link rel="/apple-touch-icon" sizes="114x114" href="icons/apple-icon-114x114.png">
-  <link rel="/apple-touch-icon" sizes="120x120" href="icons/apple-icon-120x120.png">
-  <link rel="/apple-touch-icon" sizes="144x144" href="icons/apple-icon-144x144.png">
-  <link rel="/apple-touch-icon" sizes="152x152" href="icons/apple-icon-152x152.png">
-  <link rel="/apple-touch-icon" sizes="180x180" href="icons/apple-icon-180x180.png">
+  <link rel="apple-touch-icon" sizes="57x57" href="icons/apple-icon-57x57.png">
+  <link rel="apple-touch-icon" sizes="60x60" href="icons/apple-icon-60x60.png">
+  <link rel="apple-touch-icon" sizes="72x72" href="icons/apple-icon-72x72.png">
+  <link rel="apple-touch-icon" sizes="76x76" href="icons/apple-icon-76x76.png">
+  <link rel="apple-touch-icon" sizes="114x114" href="icons/apple-icon-114x114.png">
+  <link rel="apple-touch-icon" sizes="120x120" href="icons/apple-icon-120x120.png">
+  <link rel="apple-touch-icon" sizes="144x144" href="icons/apple-icon-144x144.png">
+  <link rel="apple-touch-icon" sizes="152x152" href="icons/apple-icon-152x152.png">
+  <link rel="apple-touch-icon" sizes="180x180" href="icons/apple-icon-180x180.png">
   <link rel="icon" type="image/png" sizes="192x192" href="icons/android-icon-192x192.png">
   <link rel="icon" type="image/png" sizes="32x32" href="icons/favicon-32x32.png">
   <link rel="icon" type="image/png" sizes="96x96" href="icons/favicon-96x96.png">


### PR DESCRIPTION
Hello! WaveMaker is awesome! Just an absolutely fabulous project.

One thing I using it on iOS devices is that apple icons don't show up when you try to install the app to the homescreen. It looks like the forward slash in the `apple-touch-icon` metadata was behind the bug. I tested it on an iPhone X running iOS 12 and an iPad running iPadOS 13 and it works.

Cheers! 🍻