### PR TITLE
Swiping on a editor tree node will open the context menu

### DIFF
--- a/tools/writer/script.js
+++ b/tools/writer/script.js
@@ -816,3 +816,12 @@ function ShowWordCount(counted) {
 }
 
 setManuscript();
+
+//Context Menu on swipe
+let treenodes = document.querySelectorAll('.fancytree-node')
+treenodes.forEach((node) => {
+  let hammertime = new Hammer(node)
+  hammertime.on('swipe', () => {
+    $(node).trigger('contextmenu')
+  })
+})


### PR DESCRIPTION
Using the writer tool on mobile can be a little difficult, since there's no right click to open the context menu for delete/rename/copy, etc. This uses hammer.js to open the context menu when you swipe across a tree node. I've tested on Chrome and Edge on Windows 10 and an iPhone running iOS 13 and it works perfectly. (Note that I haven't tested on Chrome on Android yet.)